### PR TITLE
Fix same-filename images colliding in atlas and selection

### DIFF
--- a/src/app/preview_panel.rs
+++ b/src/app/preview_panel.rs
@@ -81,24 +81,16 @@ fn render_preview(app: &mut ZephyrApp, ui: &mut Ui) {
 
             let selected_image_ids = collect_selected_image_ids(&app.tree_root, &app.selected_nodes);
 
-            // Pre-compute which placement names are selected so opacity rendering
+            // Pre-compute which placement node_ids are selected so opacity rendering
             // and selection boxes both use the same set without repeating the tree walk.
-            let selected_names: HashSet<String> = if selected_image_ids.is_empty() {
-                HashSet::new()
-            } else {
-                atlas
-                    .placements
-                    .iter()
-                    .filter_map(|p| {
-                        app.tree_root
-                            .find_image_id_by_name(&p.name)
-                            .filter(|id| selected_image_ids.contains(id))
-                            .map(|_| p.name.clone())
-                    })
-                    .collect()
-            };
+            let selected_placement_ids: HashSet<NodeId> = atlas
+                .placements
+                .iter()
+                .filter(|p| selected_image_ids.contains(&p.node_id))
+                .map(|p| p.node_id)
+                .collect();
 
-            draw_atlas_with_opacity(ui, texture, &image_rect, &clip_rect, atlas, &selected_names, display_size);
+            draw_atlas_with_opacity(ui, texture, &image_rect, &clip_rect, atlas, &selected_placement_ids, display_size);
 
             if app.prefs.draw_border {
                 ui.painter()
@@ -106,7 +98,7 @@ fn render_preview(app: &mut ZephyrApp, ui: &mut Ui) {
                     .rect_stroke(image_rect, 0.0, (1.0, Color32::WHITE), egui::StrokeKind::Outside);
             }
 
-            draw_selection_boxes(atlas, ui, &image_rect, &clip_rect, display_size, &selected_names);
+            draw_selection_boxes(atlas, ui, &image_rect, &clip_rect, display_size, &selected_placement_ids);
 
             if response.drag_started_by(egui::PointerButton::Primary)
                 && let Some(start_pos) = response.interact_pointer_pos()
@@ -218,10 +210,10 @@ fn draw_atlas_with_opacity(
     image_rect: &Rect,
     clip_rect: &Rect,
     atlas: &crate::types::PackedAtlas,
-    selected_names: &HashSet<String>,
+    selected_ids: &HashSet<NodeId>,
     display_size: egui::Vec2,
 ) {
-    if selected_names.is_empty() {
+    if selected_ids.is_empty() {
         ui.painter()
             .with_clip_rect(*clip_rect)
             .image(texture.id(), *image_rect, Rect::from_min_max(Pos2::ZERO, Pos2::new(1.0, 1.0)), Color32::WHITE);
@@ -241,7 +233,7 @@ fn draw_atlas_with_opacity(
     );
 
     for placement in &atlas.placements {
-        if selected_names.contains(&placement.name) {
+        if selected_ids.contains(&placement.node_id) {
             let u_min = placement.x as f32 / atlas_width;
             let v_min = placement.y as f32 / atlas_height;
             let u_max = (placement.x + placement.width) as f32 / atlas_width;
@@ -277,10 +269,9 @@ fn handle_sprite_double_click(app: &mut ZephyrApp, click_pos: Pos2, image_rect: 
                 && atlas_x < placement.x + placement.width
                 && atlas_y >= placement.y
                 && atlas_y < placement.y + placement.height
-                && let Some(id) = app.tree_root.find_image_id_by_name(&placement.name)
             {
                 app.selected_nodes.clear();
-                app.selected_nodes.insert(id);
+                app.selected_nodes.insert(placement.node_id);
                 app.current_tab = AppTab::SpriteEditor;
                 break;
             }
@@ -304,10 +295,8 @@ fn handle_sprite_click(app: &mut ZephyrApp, click_pos: Pos2, image_rect: &Rect, 
     if let Some(atlas) = &app.atlas {
         for placement in &atlas.placements {
             if atlas_x >= placement.x && atlas_x < placement.x + placement.width && atlas_y >= placement.y && atlas_y < placement.y + placement.height {
-                if let Some(id) = app.tree_root.find_image_id_by_name(&placement.name) {
-                    clicked_id = Some(id);
-                    break;
-                }
+                clicked_id = Some(placement.node_id);
+                break;
             }
         }
     }
@@ -350,10 +339,8 @@ fn handle_drag_selection(app: &mut ZephyrApp, drag_rect: Rect, image_rect: &Rect
                 Pos2::new((placement.x + placement.width) as f32, (placement.y + placement.height) as f32),
             );
 
-            if sprite_rect.intersects(selection_rect_atlas)
-                && let Some(id) = app.tree_root.find_image_id_by_name(&placement.name)
-            {
-                selected_ids.insert(id);
+            if sprite_rect.intersects(selection_rect_atlas) {
+                selected_ids.insert(placement.node_id);
             }
         }
     }
@@ -367,12 +354,12 @@ fn handle_drag_selection(app: &mut ZephyrApp, drag_rect: Rect, image_rect: &Rect
     }
 }
 
-fn draw_selection_boxes(atlas: &crate::types::PackedAtlas, ui: &mut Ui, image_rect: &Rect, clip_rect: &Rect, display_size: egui::Vec2, selected_names: &HashSet<String>) {
+fn draw_selection_boxes(atlas: &crate::types::PackedAtlas, ui: &mut Ui, image_rect: &Rect, clip_rect: &Rect, display_size: egui::Vec2, selected_ids: &HashSet<NodeId>) {
     let display_pixels_per_atlas_pixel = display_size.x / atlas.width as f32;
     let image_min = image_rect.min;
 
     for placement in &atlas.placements {
-        if selected_names.contains(&placement.name) {
+        if selected_ids.contains(&placement.node_id) {
             let x = placement.x as f32 * display_pixels_per_atlas_pixel;
             let y = placement.y as f32 * display_pixels_per_atlas_pixel;
             let w = placement.width as f32 * display_pixels_per_atlas_pixel;

--- a/src/app/tree_panel.rs
+++ b/src/app/tree_panel.rs
@@ -453,6 +453,7 @@ mod tests {
                 source_height: 1,
                 trim_offset_x: 0,
                 trim_offset_y: 0,
+                node_id: 0,
             },
         })
     }

--- a/src/atlas.rs
+++ b/src/atlas.rs
@@ -2,17 +2,19 @@
 // Licensed under the MIT license.
 // See LICENSE file in the project root for full license information.
 
-use crate::types::{AlphaProcessing, Placement, SourceImage};
+use crate::types::{AlphaProcessing, NodeId, Placement, SourceImage};
 use image::{RgbaImage, imageops};
 use std::collections::HashMap;
 
 pub(crate) fn create_atlas_texture(placements: &[Placement], images: &[SourceImage], width: u32, height: u32, extrude: u32, alpha_processing: AlphaProcessing) -> RgbaImage {
     let mut atlas = RgbaImage::new(width, height);
 
-    let image_map: HashMap<_, _> = images.iter().map(|img| (img.name.as_str(), img)).collect();
+    // Keyed by NodeId rather than name so that two images with the same filename
+    // but different directory roots remain distinct entries.
+    let image_map: HashMap<NodeId, &SourceImage> = images.iter().map(|img| (img.node_id, img)).collect();
 
     for placement in placements {
-        if let Some(src_img) = image_map.get(placement.name.as_str()) {
+        if let Some(src_img) = image_map.get(&placement.node_id) {
             let processed_image = apply_alpha_processing(&src_img.data, alpha_processing);
 
             if let Err(e) = copy_image_to_atlas(&mut atlas, &processed_image, placement.x, placement.y, extrude) {
@@ -216,6 +218,7 @@ pub(crate) fn apply_trim(images: Vec<SourceImage>) -> Vec<SourceImage> {
                 trim_offset_y: trim_y,
                 name: img.name,
                 path: img.path,
+                node_id: img.node_id,
             }
         })
         .collect()
@@ -270,6 +273,7 @@ mod tests {
             trim_offset_y: 0,
             name: "s".to_string(),
             path: None,
+            node_id: 0,
         };
         let result = apply_trim(vec![img]);
         let out = &result[0];
@@ -297,6 +301,7 @@ mod tests {
             trim_offset_y: 0,
             name: "s".to_string(),
             path: None,
+            node_id: 0,
         };
         let result = apply_trim(vec![img]);
         let out = &result[0];

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -199,7 +199,7 @@ fn run_export(args: &[String]) -> i32 {
         return 1;
     }
 
-    let images = load_images(&image_paths);
+    let mut images = load_images(&image_paths);
 
     if images.is_empty() {
         eprintln!("error: no images could be loaded");
@@ -212,6 +212,12 @@ fn run_export(args: &[String]) -> i32 {
             image_paths.len() - images.len(),
             image_paths.len()
         );
+    }
+
+    // Assign sequential node_ids so that images with the same filename but
+    // different paths remain distinct when keyed by id inside create_atlas_texture.
+    for (i, img) in images.iter_mut().enumerate() {
+        img.node_id = i + 1;
     }
 
     let images_to_pack = if parsed.settings.trim_mode == TrimMode::Off {

--- a/src/export.rs
+++ b/src/export.rs
@@ -324,6 +324,7 @@ mod tests {
                 source_height: 32,
                 trim_offset_x: 0,
                 trim_offset_y: 0,
+                node_id: 0,
             }],
         };
 
@@ -376,6 +377,7 @@ mod tests {
                     source_height: 32,
                     trim_offset_x: 4,
                     trim_offset_y: 6,
+                    node_id: 0,
                 },
                 Placement {
                     name: "untrimmed".to_string(),
@@ -387,6 +389,7 @@ mod tests {
                     source_height: 32,
                     trim_offset_x: 0,
                     trim_offset_y: 0,
+                    node_id: 0,
                 },
             ],
         };
@@ -417,6 +420,7 @@ mod tests {
                 source_height: 32,
                 trim_offset_x: 0,
                 trim_offset_y: 0,
+                node_id: 0,
             }],
         };
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -24,6 +24,7 @@ pub(crate) fn load_image(path: &Path) -> Result<SourceImage, LoadError> {
         source_height: height,
         trim_offset_x: 0,
         trim_offset_y: 0,
+        node_id: 0,
     })
 }
 

--- a/src/packing.rs
+++ b/src/packing.rs
@@ -169,6 +169,7 @@ fn pack_shelf(images: &[SourceImage], atlas_width: u32, atlas_height: u32, setti
                 source_height: img.source_height,
                 trim_offset_x: img.trim_offset_x,
                 trim_offset_y: img.trim_offset_y,
+                node_id: img.node_id,
             });
 
             current_x += new_slot_width;
@@ -197,6 +198,7 @@ fn pack_shelf(images: &[SourceImage], atlas_width: u32, atlas_height: u32, setti
             source_height: img.source_height,
             trim_offset_x: img.trim_offset_x,
             trim_offset_y: img.trim_offset_y,
+            node_id: img.node_id,
         });
 
         current_x += slot_width;
@@ -316,6 +318,7 @@ fn pack_maxrects(images: &[SourceImage], atlas_width: u32, atlas_height: u32, se
                 source_height: img.source_height,
                 trim_offset_x: img.trim_offset_x,
                 trim_offset_y: img.trim_offset_y,
+                node_id: img.node_id,
             });
 
             // Split all free rectangles that intersect with the placed rectangle
@@ -432,6 +435,7 @@ mod tests {
             source_height: size,
             trim_offset_x: 0,
             trim_offset_y: 0,
+            node_id: 0,
         }
     }
 
@@ -456,6 +460,7 @@ mod tests {
             source_height: height,
             trim_offset_x: 0,
             trim_offset_y: 0,
+            node_id: 0,
         }
     }
 

--- a/src/types/project.rs
+++ b/src/types/project.rs
@@ -11,7 +11,7 @@ use serde::{Deserialize, Serialize};
 use super::animation::Animation;
 use super::settings::PackSettings;
 use super::sprite::SpriteProperties;
-use super::tree::TreeNode;
+use super::tree::{NodeId, TreeNode};
 
 // Increment this only when the .zephyr file schema changes in a
 // backwards-incompatible way. It is intentionally decoupled from the
@@ -48,6 +48,11 @@ pub(crate) struct SourceImage {
     pub(crate) trim_offset_x: u32,
     #[serde(skip)]
     pub(crate) trim_offset_y: u32,
+
+    // The NodeId of the tree leaf this image came from. Zero for images not loaded
+    // through the project tree (e.g. CLI). Set by collect_images; not persisted.
+    #[serde(skip)]
+    pub(crate) node_id: NodeId,
 }
 
 fn default_rgba_image() -> RgbaImage {
@@ -72,6 +77,9 @@ pub(crate) struct Placement {
     pub(crate) source_height: u32,
     pub(crate) trim_offset_x: u32,
     pub(crate) trim_offset_y: u32,
+    // The NodeId of the source tree leaf. Not included in serialized atlas output.
+    #[serde(skip)]
+    pub(crate) node_id: NodeId,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -122,6 +130,7 @@ mod tests {
                     source_height: 32,
                     trim_offset_x: 0,
                     trim_offset_y: 0,
+                    node_id: 0,
                 },
             }),
             TreeNode::Image(ImageNode {
@@ -136,6 +145,7 @@ mod tests {
                     source_height: 64,
                     trim_offset_x: 0,
                     trim_offset_y: 0,
+                    node_id: 0,
                 },
             }),
         ];

--- a/src/types/tree.rs
+++ b/src/types/tree.rs
@@ -42,15 +42,13 @@ impl TreeNode {
     }
 
     pub(crate) fn collect_images(&self) -> Vec<SourceImage> {
-        self.iter_images().map(|img_node| img_node.image.clone()).collect()
-    }
-
-    pub(crate) fn find_image_by_name(&self, name: &str) -> Option<&ImageNode> {
-        self.iter_images().find(|img| img.image.name == name)
-    }
-
-    pub(crate) fn find_image_id_by_name(&self, name: &str) -> Option<NodeId> {
-        self.find_image_by_name(name).map(|img| img.id)
+        self.iter_images()
+            .map(|img_node| {
+                let mut image = img_node.image.clone();
+                image.node_id = img_node.id;
+                image
+            })
+            .collect()
     }
 
     pub(crate) fn reload_images(&mut self) -> (usize, usize) {
@@ -303,6 +301,7 @@ mod tests {
             source_height: 1,
             trim_offset_x: 0,
             trim_offset_y: 0,
+            node_id: 0,
         }
     }
 


### PR DESCRIPTION
## Prerequisites

- [x] I have verified that there are no existing pull requests that would overlap with this pull request.
- [x] I have verified that I am following the guidelines as outlined in this project's contribution policy
- [x] I Have verified that this pull request adheres to this project's code of conduct.
- [x] I have written a descriptive title for this pull request.
- [x] I have provided appropriate test coverage were applicable.

## Description

Two images with the same name but different directory roots shared a single identity throughout the pipeline. The atlas texture only rendered one of them (HashMap key collision on name), and clicking or highlighting either placement in the UI always resolved to the same tree node.

Add node_id to SourceImage and Placement so each placement is tied to its originating tree leaf by stable unique ID rather than filename.

## Related Issue Ticket Numbers
- Closes #2
